### PR TITLE
La til mock-datoer for mai og september

### DIFF
--- a/src/data/stores/app-store.ts
+++ b/src/data/stores/app-store.ts
@@ -10,7 +10,7 @@ const mockKvitteringer: Array<KvitteringInterface> = [
     navn: 'foo.txt',
     størrelse: 1024 * 920,
     beløp: 32.2,
-    dato: new Date(),
+    dato: new Date('2020-05-01'),
     transportmiddel: Transportmiddel.EGEN_BIL,
   },
   {
@@ -18,7 +18,7 @@ const mockKvitteringer: Array<KvitteringInterface> = [
     navn: 'bar.jpg',
     størrelse: 812 * 920,
     beløp: 2.2,
-    dato: new Date(),
+    dato: new Date('2034-09-29'),
     transportmiddel: Transportmiddel.TAXI,
   },
 ];


### PR DESCRIPTION
Denne her er bare for å være irriterende, men det er kanskje viktig at løsningen vår skal støtte alle årets måneder, ikke bare juli. Så nå har jeg lagt inn mock-dato fra den korteste og den lengste måneden (i antall bokstaver, ikke dager):
<img width="251" alt="image" src="https://user-images.githubusercontent.com/12127271/88936350-19958700-d283-11ea-9a1a-e1d727b25b9a.png">
